### PR TITLE
Updating the version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer.json require entry:
 
 ```json
 {
-   "dcarbone/php-fhir-generated": "DSTU2"
+   "dcarbone/php-fhir-generated": "dev-DSTU2"
 }
 ```
 


### PR DESCRIPTION
I am not sure since when, but the current version of composer (1.3.0) requires the version constraint to have the `dev-` prefix if using a branch.